### PR TITLE
feat(employee): add backend employee management module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <testcontainers.version>1.19.7</testcontainers.version>
         <mybatis-plus.version>3.5.3.1</mybatis-plus.version>
+        <lombok.version>1.18.32</lombok.version>
     </properties>
 
     <!-- 依赖声明 -->
@@ -228,6 +229,11 @@
                 <groupId>com.baomidou</groupId>
                 <artifactId>mybatis-plus-boot-starter</artifactId>
                 <version>${mybatis-plus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysDeptController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysDeptController.java
@@ -126,6 +126,10 @@ public class SysDeptController extends BaseController
         {
             return warn("部门存在用户,不允许删除");
         }
+        if (deptService.checkDeptExistEmployee(deptId))
+        {
+            return warn("部门存在员工,请先重新分配");
+        }
         deptService.checkDeptDataScope(deptId);
         return toAjax(deptService.deleteDeptById(deptId));
     }

--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysEmployeeController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysEmployeeController.java
@@ -1,0 +1,165 @@
+package com.ruoyi.web.controller.system;
+
+import com.ruoyi.common.annotation.Log;
+import com.ruoyi.common.core.controller.BaseController;
+import com.ruoyi.common.core.domain.AjaxResult;
+import com.ruoyi.common.core.domain.entity.SysUser;
+import com.ruoyi.common.core.page.TableDataInfo;
+import com.ruoyi.common.enums.BusinessType;
+import com.ruoyi.common.utils.poi.ExcelUtil;
+import com.ruoyi.system.domain.employee.SysEmployee;
+import com.ruoyi.system.domain.employee.SysUserEmployee;
+import com.ruoyi.system.service.ISysEmployeeService;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 员工管理控制器。
+ */
+@RestController
+@RequestMapping("/system/employee")
+public class SysEmployeeController extends BaseController
+{
+    @Autowired
+    private ISysEmployeeService employeeService;
+
+    /**
+     * 查询员工列表。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:list')")
+    @GetMapping("/list")
+    public TableDataInfo list(SysEmployee employee)
+    {
+        startPage();
+        List<SysEmployee> list = employeeService.selectEmployeeList(employee);
+        return getDataTable(list);
+    }
+
+    /**
+     * 导出员工数据。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:export')")
+    @Log(title = "员工管理", businessType = BusinessType.EXPORT)
+    @GetMapping("/export")
+    public void export(HttpServletResponse response, SysEmployee employee)
+    {
+        List<SysEmployee> list = employeeService.selectEmployeeList(employee);
+        ExcelUtil<SysEmployee> util = new ExcelUtil<>(SysEmployee.class);
+        util.exportExcel(response, list, "员工数据");
+    }
+
+    /**
+     * 获取员工详情。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:query')")
+    @GetMapping("/{employeeId}")
+    public AjaxResult getInfo(@PathVariable Long employeeId)
+    {
+        return success(employeeService.selectEmployeeById(employeeId));
+    }
+
+    /**
+     * 新增员工。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:add')")
+    @Log(title = "员工管理", businessType = BusinessType.INSERT)
+    @PostMapping
+    public AjaxResult add(@Validated @RequestBody SysEmployee employee)
+    {
+        employee.setCreateBy(getUsername());
+        return toAjax(employeeService.insertEmployee(employee));
+    }
+
+    /**
+     * 修改员工。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:edit')")
+    @Log(title = "员工管理", businessType = BusinessType.UPDATE)
+    @PutMapping
+    public AjaxResult edit(@Validated @RequestBody SysEmployee employee)
+    {
+        employee.setUpdateBy(getUsername());
+        return toAjax(employeeService.updateEmployee(employee));
+    }
+
+    /**
+     * 删除员工。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:remove')")
+    @Log(title = "员工管理", businessType = BusinessType.DELETE)
+    @DeleteMapping("/{employeeIds}")
+    public AjaxResult remove(@PathVariable Long[] employeeIds)
+    {
+        return toAjax(employeeService.deleteEmployeeByIds(employeeIds));
+    }
+
+    /**
+     * 修改员工状态。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:edit')")
+    @Log(title = "员工管理", businessType = BusinessType.UPDATE)
+    @PutMapping("/changeStatus")
+    public AjaxResult changeStatus(@RequestBody SysEmployee employee)
+    {
+        employee.setUpdateBy(getUsername());
+        return toAjax(employeeService.updateEmployeeStatus(employee));
+    }
+
+    /**
+     * 查询可选员工列表。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:list')")
+    @GetMapping("/options")
+    public AjaxResult options(String keyword, Boolean excludeBound, Long includeEmployeeId)
+    {
+        List<SysEmployee> list = employeeService.selectEmployeeOptions(keyword, Boolean.TRUE.equals(excludeBound), includeEmployeeId);
+        return success(list);
+    }
+
+    /**
+     * 查询可绑定账号列表。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:bind')")
+    @GetMapping("/bind/candidates")
+    public AjaxResult bindCandidates(String keyword, Long employeeId)
+    {
+        List<SysUser> list = employeeService.selectBindableUsers(keyword, employeeId);
+        return success(list);
+    }
+
+    /**
+     * 绑定账号。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:bind')")
+    @Log(title = "员工管理", businessType = BusinessType.UPDATE)
+    @PostMapping("/bind")
+    public AjaxResult bind(@RequestBody SysUserEmployee request)
+    {
+        employeeService.bindUser(request.getEmployeeId(), request.getUserId());
+        return success();
+    }
+
+    /**
+     * 解绑账号。
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:bind')")
+    @Log(title = "员工管理", businessType = BusinessType.UPDATE)
+    @DeleteMapping("/{employeeId}/bind")
+    public AjaxResult unbind(@PathVariable Long employeeId)
+    {
+        employeeService.unbindByEmployeeId(employeeId);
+        return success();
+    }
+}
+

--- a/ruoyi-common/src/main/java/com/ruoyi/common/core/domain/entity/SysUser.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/core/domain/entity/SysUser.java
@@ -29,6 +29,17 @@ public class SysUser extends BaseEntity
     @Excel(name = "部门编号", type = Type.IMPORT)
     private Long deptId;
 
+    /** 绑定员工ID */
+    private Long employeeId;
+
+    /** 绑定员工编号 */
+    @Excel(name = "绑定员工编号", type = Type.EXPORT)
+    private String employeeCode;
+
+    /** 绑定员工姓名 */
+    @Excel(name = "绑定员工", type = Type.EXPORT)
+    private String employeeName;
+
     /** 用户账号 */
     @Excel(name = "登录名称")
     private String userName;
@@ -130,6 +141,36 @@ public class SysUser extends BaseEntity
     public void setDeptId(Long deptId)
     {
         this.deptId = deptId;
+    }
+
+    public Long getEmployeeId()
+    {
+        return employeeId;
+    }
+
+    public void setEmployeeId(Long employeeId)
+    {
+        this.employeeId = employeeId;
+    }
+
+    public String getEmployeeCode()
+    {
+        return employeeCode;
+    }
+
+    public void setEmployeeCode(String employeeCode)
+    {
+        this.employeeCode = employeeCode;
+    }
+
+    public String getEmployeeName()
+    {
+        return employeeName;
+    }
+
+    public void setEmployeeName(String employeeName)
+    {
+        this.employeeName = employeeName;
     }
 
     @Xss(message = "用户昵称不能包含脚本字符")
@@ -314,7 +355,10 @@ public class SysUser extends BaseEntity
     public String toString() {
         return new ToStringBuilder(this,ToStringStyle.MULTI_LINE_STYLE)
             .append("userId", getUserId())
-            .append("deptId", getDeptId())
+                .append("deptId", getDeptId())
+                .append("employeeId", getEmployeeId())
+                .append("employeeCode", getEmployeeCode())
+                .append("employeeName", getEmployeeName())
             .append("userName", getUserName())
             .append("nickName", getNickName())
             .append("email", getEmail())

--- a/ruoyi-system/pom.xml
+++ b/ruoyi-system/pom.xml
@@ -23,6 +23,12 @@
             <artifactId>ruoyi-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysEmployee.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysEmployee.java
@@ -1,0 +1,110 @@
+package com.ruoyi.system.domain.employee;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ruoyi.common.annotation.Excel;
+import com.ruoyi.common.core.domain.BaseEntity;
+import com.ruoyi.common.core.domain.entity.SysUser;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * 员工信息实体。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@TableName("sys_employee")
+public class SysEmployee extends BaseEntity implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @TableId(value = "employee_id", type = IdType.AUTO)
+    private Long employeeId;
+
+    @TableField("employee_code")
+    @Excel(name = "员工编号")
+    private String employeeCode;
+
+    @TableField("employee_name")
+    @Excel(name = "员工姓名")
+    private String employeeName;
+
+    @TableField("job_title")
+    @Excel(name = "岗位")
+    private String jobTitle;
+
+    @TableField("entry_date")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Excel(name = "入职日期", width = 20, dateFormat = "yyyy-MM-dd")
+    private LocalDate entryDate;
+
+    @TableField("mobile")
+    @Excel(name = "联系方式")
+    private String mobile;
+
+    @TableField("email")
+    @Excel(name = "邮箱")
+    private String email;
+
+    @TableField("status")
+    @Excel(name = "状态", readConverterExp = "0=在职,1=离职")
+    private String status;
+
+    @TableLogic(value = "0", delval = "2")
+    @TableField("del_flag")
+    private String delFlag;
+
+    @TableField(exist = false)
+    private Long deptId;
+
+    @TableField(exist = false)
+    private List<Long> deptIds;
+
+    @TableField(exist = false)
+    private List<String> deptNames;
+
+    @TableField(exist = false)
+    private SysUser bindUser;
+
+    public List<Long> getDeptIds()
+    {
+        if (deptIds == null)
+        {
+            deptIds = new ArrayList<>();
+        }
+        return deptIds;
+    }
+
+    public void setDeptIds(List<Long> deptIds)
+    {
+        this.deptIds = deptIds;
+    }
+
+    public List<String> getDeptNames()
+    {
+        if (deptNames == null)
+        {
+            deptNames = new ArrayList<>();
+        }
+        return deptNames;
+    }
+
+    public void setDeptNames(List<String> deptNames)
+    {
+        this.deptNames = deptNames;
+    }
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysEmployeeDept.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysEmployeeDept.java
@@ -1,0 +1,37 @@
+package com.ruoyi.system.domain.employee;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 员工与部门关联实体。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@TableName("sys_employee_dept")
+public class SysEmployeeDept implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    @TableField("employee_id")
+    private Long employeeId;
+
+    @TableField("dept_id")
+    private Long deptId;
+
+    @TableField("create_time")
+    private LocalDateTime createTime;
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysUserEmployee.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/domain/employee/SysUserEmployee.java
@@ -1,0 +1,37 @@
+package com.ruoyi.system.domain.employee;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 账号与员工绑定实体。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@TableName("sys_user_employee")
+public class SysUserEmployee implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    @TableField("user_id")
+    private Long userId;
+
+    @TableField("employee_id")
+    private Long employeeId;
+
+    @TableField("create_time")
+    private LocalDateTime createTime;
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysDeptMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysDeptMapper.java
@@ -69,6 +69,14 @@ public interface SysDeptMapper
     public int checkDeptExistUser(Long deptId);
 
     /**
+     * 查询部门是否存在员工。
+     *
+     * @param deptId 部门ID
+     * @return 结果
+     */
+    public int checkDeptExistEmployee(Long deptId);
+
+    /**
      * 校验部门名称是否唯一
      * 
      * @param deptName 部门名称
@@ -115,4 +123,12 @@ public interface SysDeptMapper
      * @return 结果
      */
     public int deleteDeptById(Long deptId);
+
+    /**
+     * 根据ID集合查询部门。
+     *
+     * @param deptIds 部门ID集合
+     * @return 部门列表
+     */
+    public List<SysDept> selectDeptByIds(@Param("deptIds") List<Long> deptIds);
 }

--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysEmployeeDeptMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysEmployeeDeptMapper.java
@@ -1,0 +1,13 @@
+package com.ruoyi.system.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.ruoyi.system.domain.employee.SysEmployeeDept;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 员工与部门关系Mapper。
+ */
+@Mapper
+public interface SysEmployeeDeptMapper extends BaseMapper<SysEmployeeDept>
+{
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysEmployeeMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysEmployeeMapper.java
@@ -1,0 +1,13 @@
+package com.ruoyi.system.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.ruoyi.system.domain.employee.SysEmployee;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 员工信息Mapper。
+ */
+@Mapper
+public interface SysEmployeeMapper extends BaseMapper<SysEmployee>
+{
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysUserEmployeeMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysUserEmployeeMapper.java
@@ -1,0 +1,44 @@
+package com.ruoyi.system.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.ruoyi.common.core.domain.entity.SysUser;
+import com.ruoyi.system.domain.employee.SysUserEmployee;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+/**
+ * 账号与员工绑定Mapper。
+ */
+@Mapper
+public interface SysUserEmployeeMapper extends BaseMapper<SysUserEmployee>
+{
+    /**
+     * 查询可绑定账号列表。
+     *
+     * @param keyword 关键字
+     * @param employeeId 员工ID
+     * @return 账号集合
+     */
+    @Select(value = "<script>"
+            + "SELECT u.user_id, u.user_name, u.nick_name, u.status "
+            + "FROM sys_user u "
+            + "LEFT JOIN sys_user_employee sue ON sue.user_id = u.user_id "
+            + "<where>"
+            + " u.del_flag = '0' "
+            + "<if test='keyword != null and keyword != \"\"'>"
+            + " AND (u.user_name LIKE CONCAT('%', #{keyword}, '%') OR u.nick_name LIKE CONCAT('%', #{keyword}, '%'))"
+            + "</if>"
+            + "<if test='employeeId != null'>"
+            + " AND (sue.user_id IS NULL OR sue.employee_id = #{employeeId})"
+            + "</if>"
+            + "<if test='employeeId == null'>"
+            + " AND sue.user_id IS NULL"
+            + "</if>"
+            + "</where>"
+            + " ORDER BY u.create_time DESC"
+            + " LIMIT 20"
+            + "</script>")
+    List<SysUser> selectBindableUsers(@Param("keyword") String keyword, @Param("employeeId") Long employeeId);
+}

--- a/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysUserMapper.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/mapper/SysUserMapper.java
@@ -124,4 +124,12 @@ public interface SysUserMapper
      * @return 结果
      */
     public SysUser checkEmailUnique(String email);
+
+    /**
+     * 根据ID集合查询账号简要信息。
+     *
+     * @param userIds 用户ID集合
+     * @return 用户列表
+     */
+    public List<SysUser> selectSimpleUserListByIds(@Param("userIds") List<Long> userIds);
 }

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/ISysDeptService.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/ISysDeptService.java
@@ -84,6 +84,14 @@ public interface ISysDeptService
     public boolean checkDeptExistUser(Long deptId);
 
     /**
+     * 查询部门是否存在员工。
+     *
+     * @param deptId 部门ID
+     * @return 结果
+     */
+    public boolean checkDeptExistEmployee(Long deptId);
+
+    /**
      * 校验部门名称是否唯一
      * 
      * @param dept 部门信息

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/ISysEmployeeService.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/ISysEmployeeService.java
@@ -1,0 +1,101 @@
+package com.ruoyi.system.service;
+
+import com.ruoyi.common.core.domain.entity.SysUser;
+import com.ruoyi.system.domain.employee.SysEmployee;
+import java.util.List;
+
+/**
+ * 员工管理服务接口。
+ */
+public interface ISysEmployeeService
+{
+    /**
+     * 查询员工列表。
+     *
+     * @param employee 查询参数
+     * @return 员工集合
+     */
+    List<SysEmployee> selectEmployeeList(SysEmployee employee);
+
+    /**
+     * 查询员工详情。
+     *
+     * @param employeeId 员工ID
+     * @return 员工信息
+     */
+    SysEmployee selectEmployeeById(Long employeeId);
+
+    /**
+     * 新增员工。
+     *
+     * @param employee 员工信息
+     * @return 结果
+     */
+    int insertEmployee(SysEmployee employee);
+
+    /**
+     * 更新员工。
+     *
+     * @param employee 员工信息
+     * @return 结果
+     */
+    int updateEmployee(SysEmployee employee);
+
+    /**
+     * 删除员工。
+     *
+     * @param employeeIds 员工ID数组
+     * @return 结果
+     */
+    int deleteEmployeeByIds(Long[] employeeIds);
+
+    /**
+     * 修改员工状态。
+     *
+     * @param employee 员工信息
+     * @return 结果
+     */
+    int updateEmployeeStatus(SysEmployee employee);
+
+    /**
+     * 查询可选员工列表。
+     *
+     * @param keyword 关键字
+     * @param excludeBound 是否排除已绑定员工
+     * @param includeEmployeeId 额外包含的员工ID
+     * @return 员工集合
+     */
+    List<SysEmployee> selectEmployeeOptions(String keyword, boolean excludeBound, Long includeEmployeeId);
+
+    /**
+     * 查询可绑定账号列表。
+     *
+     * @param keyword 关键字
+     * @param employeeId 员工ID
+     * @return 账号集合
+     */
+    List<SysUser> selectBindableUsers(String keyword, Long employeeId);
+
+    /**
+     * 绑定账号。
+     *
+     * @param employeeId 员工ID
+     * @param userId 账号ID
+     */
+    void bindUser(Long employeeId, Long userId);
+
+    /**
+     * 根据员工解除绑定。
+     *
+     * @param employeeId 员工ID
+     */
+    void unbindByEmployeeId(Long employeeId);
+
+    /**
+     * 根据账号解除绑定。
+     *
+     * @param userId 账号ID
+     */
+    void unbindByUserId(Long userId);
+}
+

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysDeptServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysDeptServiceImpl.java
@@ -164,6 +164,13 @@ public class SysDeptServiceImpl implements ISysDeptService
         return result > 0;
     }
 
+    @Override
+    public boolean checkDeptExistEmployee(Long deptId)
+    {
+        int result = deptMapper.checkDeptExistEmployee(deptId);
+        return result > 0;
+    }
+
     /**
      * 校验部门名称是否唯一
      * 

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysEmployeeServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysEmployeeServiceImpl.java
@@ -1,0 +1,447 @@
+package com.ruoyi.system.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.ruoyi.common.annotation.DataScope;
+import com.ruoyi.common.constant.UserConstants;
+import com.ruoyi.common.core.domain.entity.SysDept;
+import com.ruoyi.common.core.domain.entity.SysUser;
+import com.ruoyi.common.exception.ServiceException;
+import com.ruoyi.common.utils.StringUtils;
+import com.ruoyi.system.domain.employee.SysEmployee;
+import com.ruoyi.system.domain.employee.SysEmployeeDept;
+import com.ruoyi.system.domain.employee.SysUserEmployee;
+import com.ruoyi.system.mapper.SysDeptMapper;
+import com.ruoyi.system.mapper.SysEmployeeDeptMapper;
+import com.ruoyi.system.mapper.SysEmployeeMapper;
+import com.ruoyi.system.mapper.SysUserEmployeeMapper;
+import com.ruoyi.system.mapper.SysUserMapper;
+import com.ruoyi.system.service.ISysDeptService;
+import com.ruoyi.system.service.ISysEmployeeService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 员工管理服务实现。
+ */
+@Service
+public class SysEmployeeServiceImpl extends ServiceImpl<SysEmployeeMapper, SysEmployee> implements ISysEmployeeService
+{
+    private static final String DATA_SCOPE = "dataScope";
+
+    @Autowired
+    private SysEmployeeDeptMapper employeeDeptMapper;
+
+    @Autowired
+    private SysUserEmployeeMapper userEmployeeMapper;
+
+    @Autowired
+    private SysDeptMapper deptMapper;
+
+    @Autowired
+    private SysUserMapper userMapper;
+
+    @Autowired
+    private ISysDeptService deptService;
+
+    @Override
+    @DataScope(deptAlias = "d")
+    public List<SysEmployee> selectEmployeeList(SysEmployee employee)
+    {
+        LambdaQueryWrapper<SysEmployee> wrapper = buildQueryWrapper(employee);
+        List<SysEmployee> employees = list(wrapper);
+        attachRelations(employees, true);
+        return employees;
+    }
+
+    @Override
+    public SysEmployee selectEmployeeById(Long employeeId)
+    {
+        if (employeeId == null)
+        {
+            return null;
+        }
+        SysEmployee employee = getById(employeeId);
+        if (employee == null)
+        {
+            return null;
+        }
+        attachRelations(Collections.singletonList(employee), true);
+        return employee;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int insertEmployee(SysEmployee employee)
+    {
+        validateEmployee(employee, true);
+        if (StringUtils.isEmpty(employee.getStatus()))
+        {
+            employee.setStatus(UserConstants.NORMAL);
+        }
+        employee.setCreateTime(new Date());
+        employee.setDelFlag(UserConstants.NORMAL);
+        boolean result = save(employee);
+        if (!result)
+        {
+            throw new ServiceException("新增员工失败，请重试");
+        }
+        saveEmployeeDepts(employee.getEmployeeId(), employee.getDeptIds());
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int updateEmployee(SysEmployee employee)
+    {
+        validateEmployee(employee, false);
+        employee.setUpdateTime(new Date());
+        boolean result = updateById(employee);
+        if (!result)
+        {
+            throw new ServiceException("更新员工失败，请重试");
+        }
+        // 更新部门关联
+        employeeDeptMapper.delete(new LambdaQueryWrapper<SysEmployeeDept>().eq(SysEmployeeDept::getEmployeeId, employee.getEmployeeId()));
+        saveEmployeeDepts(employee.getEmployeeId(), employee.getDeptIds());
+        return 1;
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int deleteEmployeeByIds(Long[] employeeIds)
+    {
+        if (employeeIds == null || employeeIds.length == 0)
+        {
+            return 0;
+        }
+        List<Long> ids = Arrays.stream(employeeIds).filter(id -> id != null).collect(Collectors.toList());
+        if (ids.isEmpty())
+        {
+            return 0;
+        }
+        removeByIds(ids);
+        employeeDeptMapper.delete(new LambdaQueryWrapper<SysEmployeeDept>().in(SysEmployeeDept::getEmployeeId, ids));
+        userEmployeeMapper.delete(new LambdaQueryWrapper<SysUserEmployee>().in(SysUserEmployee::getEmployeeId, ids));
+        return ids.size();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public int updateEmployeeStatus(SysEmployee employee)
+    {
+        if (employee == null || employee.getEmployeeId() == null)
+        {
+            return 0;
+        }
+        LambdaUpdateWrapper<SysEmployee> updateWrapper = new LambdaUpdateWrapper<>();
+        updateWrapper.eq(SysEmployee::getEmployeeId, employee.getEmployeeId())
+                .set(SysEmployee::getStatus, employee.getStatus())
+                .set(StringUtils.isNotEmpty(employee.getUpdateBy()), SysEmployee::getUpdateBy, employee.getUpdateBy())
+                .set(SysEmployee::getUpdateTime, new Date());
+        return update(updateWrapper) ? 1 : 0;
+    }
+
+    @Override
+    public List<SysEmployee> selectEmployeeOptions(String keyword, boolean excludeBound, Long includeEmployeeId)
+    {
+        LambdaQueryWrapper<SysEmployee> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(SysEmployee::getDelFlag, UserConstants.NORMAL)
+                .eq(SysEmployee::getStatus, UserConstants.NORMAL);
+        if (StringUtils.isNotEmpty(keyword))
+        {
+            wrapper.and(w -> w.like(SysEmployee::getEmployeeCode, keyword)
+                    .or().like(SysEmployee::getEmployeeName, keyword));
+        }
+        if (excludeBound)
+        {
+            wrapper.notInSql(SysEmployee::getEmployeeId, "select employee_id from sys_user_employee");
+        }
+        wrapper.orderByAsc(SysEmployee::getEmployeeCode).last("limit 50");
+        List<SysEmployee> list = list(wrapper);
+        if (includeEmployeeId != null)
+        {
+            SysEmployee include = getById(includeEmployeeId);
+            if (include != null && list.stream().noneMatch(item -> item.getEmployeeId().equals(includeEmployeeId)))
+            {
+                list.add(0, include);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public List<SysUser> selectBindableUsers(String keyword, Long employeeId)
+    {
+        return userEmployeeMapper.selectBindableUsers(keyword, employeeId);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void bindUser(Long employeeId, Long userId)
+    {
+        if (employeeId == null || userId == null)
+        {
+            throw new ServiceException("绑定参数不完整");
+        }
+        SysEmployee employee = getById(employeeId);
+        if (employee == null || !UserConstants.NORMAL.equals(employee.getDelFlag()))
+        {
+            throw new ServiceException("员工不存在或已删除");
+        }
+        if (!UserConstants.NORMAL.equals(employee.getStatus()))
+        {
+            throw new ServiceException("员工状态不可用，无法绑定账号");
+        }
+        SysUser user = userMapper.selectUserById(userId);
+        if (user == null || !UserConstants.NORMAL.equals(user.getDelFlag()))
+        {
+            throw new ServiceException("账号不存在或已删除");
+        }
+        SysUserEmployee employeeBinding = userEmployeeMapper.selectOne(new LambdaQueryWrapper<SysUserEmployee>().eq(SysUserEmployee::getEmployeeId, employeeId));
+        if (employeeBinding != null && !userId.equals(employeeBinding.getUserId()))
+        {
+            throw new ServiceException("当前员工已绑定其他账号，请先解绑");
+        }
+        SysUserEmployee userBinding = userEmployeeMapper.selectOne(new LambdaQueryWrapper<SysUserEmployee>().eq(SysUserEmployee::getUserId, userId));
+        LocalDateTime now = LocalDateTime.now();
+        if (userBinding == null)
+        {
+            SysUserEmployee bind = new SysUserEmployee();
+            bind.setUserId(userId);
+            bind.setEmployeeId(employeeId);
+            bind.setCreateTime(now);
+            userEmployeeMapper.insert(bind);
+        }
+        else
+        {
+            userBinding.setEmployeeId(employeeId);
+            userBinding.setCreateTime(now);
+            userEmployeeMapper.updateById(userBinding);
+        }
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void unbindByEmployeeId(Long employeeId)
+    {
+        if (employeeId == null)
+        {
+            return;
+        }
+        userEmployeeMapper.delete(new LambdaQueryWrapper<SysUserEmployee>().eq(SysUserEmployee::getEmployeeId, employeeId));
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void unbindByUserId(Long userId)
+    {
+        if (userId == null)
+        {
+            return;
+        }
+        userEmployeeMapper.delete(new LambdaQueryWrapper<SysUserEmployee>().eq(SysUserEmployee::getUserId, userId));
+    }
+
+    private LambdaQueryWrapper<SysEmployee> buildQueryWrapper(SysEmployee employee)
+    {
+        LambdaQueryWrapper<SysEmployee> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(SysEmployee::getDelFlag, UserConstants.NORMAL);
+        if (employee != null)
+        {
+            if (StringUtils.isNotEmpty(employee.getEmployeeCode()))
+            {
+                wrapper.like(SysEmployee::getEmployeeCode, employee.getEmployeeCode());
+            }
+            if (StringUtils.isNotEmpty(employee.getEmployeeName()))
+            {
+                wrapper.like(SysEmployee::getEmployeeName, employee.getEmployeeName());
+            }
+            if (StringUtils.isNotEmpty(employee.getStatus()))
+            {
+                wrapper.eq(SysEmployee::getStatus, employee.getStatus());
+            }
+            if (employee.getDeptId() != null)
+            {
+                List<Long> deptIds = collectDeptIds(employee.getDeptId());
+                if (!deptIds.isEmpty())
+                {
+                    wrapper.inSql(SysEmployee::getEmployeeId,
+                            "SELECT employee_id FROM sys_employee_dept WHERE dept_id IN (" + StringUtils.join(deptIds, ",") + ")");
+                }
+            }
+            Object dataScope = employee.getParams().get(DATA_SCOPE);
+            if (dataScope != null && StringUtils.isNotEmpty(dataScope.toString()))
+            {
+                wrapper.apply("EXISTS (SELECT 1 FROM sys_employee_dept d WHERE d.employee_id = sys_employee.employee_id {0})", dataScope.toString());
+            }
+        }
+        wrapper.orderByDesc(SysEmployee::getCreateTime);
+        return wrapper;
+    }
+
+    private void validateEmployee(SysEmployee employee, boolean isCreate)
+    {
+        if (employee == null)
+        {
+            throw new ServiceException("员工信息不能为空");
+        }
+        if (StringUtils.isEmpty(employee.getEmployeeCode()))
+        {
+            throw new ServiceException("员工编号不能为空");
+        }
+        if (StringUtils.isEmpty(employee.getEmployeeName()))
+        {
+            throw new ServiceException("员工姓名不能为空");
+        }
+        if (CollectionUtils.isEmpty(employee.getDeptIds()))
+        {
+            throw new ServiceException("请至少选择一个所属部门");
+        }
+        // 校验编号唯一
+        LambdaQueryWrapper<SysEmployee> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(SysEmployee::getEmployeeCode, employee.getEmployeeCode())
+                .eq(SysEmployee::getDelFlag, UserConstants.NORMAL);
+        if (!isCreate && employee.getEmployeeId() != null)
+        {
+            wrapper.ne(SysEmployee::getEmployeeId, employee.getEmployeeId());
+        }
+        if (count(wrapper) > 0)
+        {
+            throw new ServiceException("员工编号已存在");
+        }
+        // 校验部门合法性
+        for (Long deptId : employee.getDeptIds())
+        {
+            if (deptId == null)
+            {
+                continue;
+            }
+            deptService.checkDeptDataScope(deptId);
+            SysDept dept = deptMapper.selectDeptById(deptId);
+            if (dept == null || !UserConstants.NORMAL.equals(dept.getDelFlag()))
+            {
+                throw new ServiceException("选择的部门不存在");
+            }
+            if (!UserConstants.DEPT_NORMAL.equals(dept.getStatus()))
+            {
+                throw new ServiceException("部门 " + dept.getDeptName() + " 已停用");
+            }
+        }
+    }
+
+    private void saveEmployeeDepts(Long employeeId, Collection<Long> deptIds)
+    {
+        if (employeeId == null || CollectionUtils.isEmpty(deptIds))
+        {
+            return;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        for (Long deptId : deptIds)
+        {
+            if (deptId == null)
+            {
+                continue;
+            }
+            SysEmployeeDept relation = new SysEmployeeDept();
+            relation.setEmployeeId(employeeId);
+            relation.setDeptId(deptId);
+            relation.setCreateTime(now);
+            employeeDeptMapper.insert(relation);
+        }
+    }
+
+    private List<Long> collectDeptIds(Long rootDeptId)
+    {
+        List<Long> ids = new ArrayList<>();
+        ids.add(rootDeptId);
+        List<SysDept> children = deptMapper.selectChildrenDeptById(rootDeptId);
+        if (CollectionUtils.isNotEmpty(children))
+        {
+            ids.addAll(children.stream().map(SysDept::getDeptId).collect(Collectors.toList()));
+        }
+        return ids;
+    }
+
+    private void attachRelations(List<SysEmployee> employees, boolean includeBindUser)
+    {
+        if (CollectionUtils.isEmpty(employees))
+        {
+            return;
+        }
+        List<Long> employeeIds = employees.stream().map(SysEmployee::getEmployeeId).collect(Collectors.toList());
+        List<SysEmployeeDept> relations = employeeDeptMapper.selectList(new LambdaQueryWrapper<SysEmployeeDept>().in(SysEmployeeDept::getEmployeeId, employeeIds));
+        Map<Long, List<Long>> employeeDeptMap = new HashMap<>();
+        if (CollectionUtils.isNotEmpty(relations))
+        {
+            for (SysEmployeeDept relation : relations)
+            {
+                employeeDeptMap.computeIfAbsent(relation.getEmployeeId(), k -> new ArrayList<>()).add(relation.getDeptId());
+            }
+        }
+        Set<Long> deptIdSet = relations.stream().map(SysEmployeeDept::getDeptId).collect(Collectors.toSet());
+        Map<Long, String> deptNameMap = new HashMap<>();
+        if (CollectionUtils.isNotEmpty(deptIdSet))
+        {
+            List<SysDept> depts = deptMapper.selectDeptByIds(new ArrayList<>(deptIdSet));
+            for (SysDept dept : depts)
+            {
+                deptNameMap.put(dept.getDeptId(), dept.getDeptName());
+            }
+        }
+        Map<Long, SysUserEmployee> bindMap = new HashMap<>();
+        Map<Long, SysUser> userMap = new HashMap<>();
+        if (includeBindUser)
+        {
+            List<SysUserEmployee> bindings = userEmployeeMapper.selectList(new LambdaQueryWrapper<SysUserEmployee>().in(SysUserEmployee::getEmployeeId, employeeIds));
+            if (CollectionUtils.isNotEmpty(bindings))
+            {
+                Set<Long> userIdSet = new HashSet<>();
+                for (SysUserEmployee binding : bindings)
+                {
+                    bindMap.put(binding.getEmployeeId(), binding);
+                    userIdSet.add(binding.getUserId());
+                }
+                if (CollectionUtils.isNotEmpty(userIdSet))
+                {
+                    List<SysUser> users = userMapper.selectSimpleUserListByIds(new ArrayList<>(userIdSet));
+                    for (SysUser user : users)
+                    {
+                        userMap.put(user.getUserId(), user);
+                    }
+                }
+            }
+        }
+        for (SysEmployee employee : employees)
+        {
+            List<Long> deptIdList = new ArrayList<>(employeeDeptMap.getOrDefault(employee.getEmployeeId(), Collections.emptyList()));
+            employee.setDeptIds(deptIdList);
+            List<String> names = deptIdList.stream().map(deptNameMap::get).filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+            employee.setDeptNames(names);
+            if (includeBindUser)
+            {
+                SysUserEmployee binding = bindMap.get(employee.getEmployeeId());
+                if (binding != null)
+                {
+                    employee.setBindUser(userMap.get(binding.getUserId()));
+                }
+            }
+        }
+    }
+}
+

--- a/ruoyi-system/src/main/resources/mapper/system/SysDeptMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysDeptMapper.xml
@@ -65,9 +65,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		where d.dept_id = #{deptId}
 	</select>
     
-    <select id="checkDeptExistUser" parameterType="Long" resultType="int">
-		select count(1) from sys_user where dept_id = #{deptId} and del_flag = '0'
-	</select>
+        <select id="checkDeptExistUser" parameterType="Long" resultType="int">
+                select count(1) from sys_user where dept_id = #{deptId} and del_flag = '0'
+        </select>
+
+        <select id="checkDeptExistEmployee" parameterType="Long" resultType="int">
+                select count(1)
+                from sys_employee_dept
+                where dept_id = #{deptId}
+        </select>
 	
 	<select id="hasChildByDeptId" parameterType="Long" resultType="int">
 		select count(1) from sys_dept
@@ -152,8 +158,19 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         </foreach>
 	</update>
 	
-	<delete id="deleteDeptById" parameterType="Long">
-		update sys_dept set del_flag = '2' where dept_id = #{deptId}
-	</delete>
+        <delete id="deleteDeptById" parameterType="Long">
+                update sys_dept set del_flag = '2' where dept_id = #{deptId}
+        </delete>
+
+        <select id="selectDeptByIds" parameterType="java.util.List" resultMap="SysDeptResult">
+                select d.dept_id, d.parent_id, d.ancestors, d.dept_name, d.order_num, d.leader, d.phone, d.email, d.status, d.del_flag,
+                       d.create_by, d.create_time, d.update_by, d.update_time
+                from sys_dept d
+                where d.del_flag = '0'
+                  and d.dept_id in
+                <foreach collection="deptIds" item="deptId" open="(" separator="," close=")">
+                        #{deptId}
+                </foreach>
+        </select>
 
 </mapper> 

--- a/ruoyi-system/src/main/resources/mapper/system/SysUserMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysUserMapper.xml
@@ -24,6 +24,9 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         <result property="updateBy"      column="update_by"       />
         <result property="updateTime"    column="update_time"     />
         <result property="remark"        column="remark"          />
+        <result property="employeeId"    column="bind_employee_id" />
+        <result property="employeeCode"  column="bind_employee_code" />
+        <result property="employeeName"  column="bind_employee_name" />
         <association property="dept"     javaType="SysDept"         resultMap="deptResult" />
         <collection  property="roles"    javaType="java.util.List"  resultMap="RoleResult" />
     </resultMap>
@@ -48,19 +51,26 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
     </resultMap>
 	
 	<sql id="selectUserVo">
-        select u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.avatar, u.phonenumber, u.password, u.sex, u.status, u.del_flag, u.login_ip, u.login_date, u.pwd_update_date, u.create_by, u.create_time, u.remark, 
+        select u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.avatar, u.phonenumber, u.password, u.sex, u.status, u.del_flag, u.login_ip, u.login_date, u.pwd_update_date, u.create_by, u.create_time, u.remark,
+        sue.employee_id as bind_employee_id, e.employee_code as bind_employee_code, e.employee_name as bind_employee_name,
         d.dept_id, d.parent_id, d.ancestors, d.dept_name, d.order_num, d.leader, d.status as dept_status,
         r.role_id, r.role_name, r.role_key, r.role_sort, r.data_scope, r.status as role_status
         from sys_user u
-		    left join sys_dept d on u.dept_id = d.dept_id
-		    left join sys_user_role ur on u.user_id = ur.user_id
-		    left join sys_role r on r.role_id = ur.role_id
+                    left join sys_user_employee sue on sue.user_id = u.user_id
+                    left join sys_employee e on sue.employee_id = e.employee_id
+                    left join sys_dept d on u.dept_id = d.dept_id
+                    left join sys_user_role ur on u.user_id = ur.user_id
+                    left join sys_role r on r.role_id = ur.role_id
     </sql>
     
     <select id="selectUserList" parameterType="SysUser" resultMap="SysUserResult">
-		select u.user_id, u.dept_id, u.nick_name, u.user_name, u.email, u.avatar, u.phonenumber, u.sex, u.status, u.del_flag, u.login_ip, u.login_date, u.create_by, u.create_time, u.remark, d.dept_name, d.leader from sys_user u
-		left join sys_dept d on u.dept_id = d.dept_id
-		where u.del_flag = '0'
+                select u.user_id, u.dept_id, u.nick_name, u.user_name, u.email, u.avatar, u.phonenumber, u.sex, u.status, u.del_flag, u.login_ip, u.login_date, u.create_by, u.create_time, u.remark, d.dept_name, d.leader,
+                sue.employee_id as bind_employee_id, e.employee_code as bind_employee_code, e.employee_name as bind_employee_name
+                from sys_user u
+                left join sys_dept d on u.dept_id = d.dept_id
+                left join sys_user_employee sue on sue.user_id = u.user_id
+                left join sys_employee e on sue.employee_id = e.employee_id
+                where u.del_flag = '0'
 		<if test="userId != null and userId != 0">
 			AND u.user_id = #{userId}
 		</if>
@@ -86,12 +96,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		${params.dataScope}
 	</select>
 	
-	<select id="selectAllocatedList" parameterType="SysUser" resultMap="SysUserResult">
-	    select distinct u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.phonenumber, u.status, u.create_time
-	    from sys_user u
-			 left join sys_dept d on u.dept_id = d.dept_id
-			 left join sys_user_role ur on u.user_id = ur.user_id
-			 left join sys_role r on r.role_id = ur.role_id
+        <select id="selectAllocatedList" parameterType="SysUser" resultMap="SysUserResult">
+            select distinct u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.phonenumber, u.status, u.create_time,
+                   sue.employee_id as bind_employee_id, e.employee_code as bind_employee_code, e.employee_name as bind_employee_name
+            from sys_user u
+                         left join sys_dept d on u.dept_id = d.dept_id
+                         left join sys_user_role ur on u.user_id = ur.user_id
+                         left join sys_role r on r.role_id = ur.role_id
+                         left join sys_user_employee sue on sue.user_id = u.user_id
+                         left join sys_employee e on sue.employee_id = e.employee_id
 	    where u.del_flag = '0' and r.role_id = #{roleId}
 	    <if test="userName != null and userName != ''">
 			AND u.user_name like concat('%', #{userName}, '%')
@@ -103,12 +116,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		${params.dataScope}
 	</select>
 	
-	<select id="selectUnallocatedList" parameterType="SysUser" resultMap="SysUserResult">
-	    select distinct u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.phonenumber, u.status, u.create_time
-	    from sys_user u
-			 left join sys_dept d on u.dept_id = d.dept_id
-			 left join sys_user_role ur on u.user_id = ur.user_id
-			 left join sys_role r on r.role_id = ur.role_id
+        <select id="selectUnallocatedList" parameterType="SysUser" resultMap="SysUserResult">
+            select distinct u.user_id, u.dept_id, u.user_name, u.nick_name, u.email, u.phonenumber, u.status, u.create_time,
+                   sue.employee_id as bind_employee_id, e.employee_code as bind_employee_code, e.employee_name as bind_employee_name
+            from sys_user u
+                         left join sys_dept d on u.dept_id = d.dept_id
+                         left join sys_user_role ur on u.user_id = ur.user_id
+                         left join sys_role r on r.role_id = ur.role_id
+                         left join sys_user_employee sue on sue.user_id = u.user_id
+                         left join sys_employee e on sue.employee_id = e.employee_id
 	    where u.del_flag = '0' and (r.role_id != #{roleId} or r.role_id IS NULL)
 	    and u.user_id not in (select u.user_id from sys_user u inner join sys_user_role ur on u.user_id = ur.user_id and ur.role_id = #{roleId})
 	    <if test="userName != null and userName != ''">
@@ -121,15 +137,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		${params.dataScope}
 	</select>
 	
-	<select id="selectUserByUserName" parameterType="String" resultMap="SysUserResult">
-	    <include refid="selectUserVo"/>
-		where u.user_name = #{userName} and u.del_flag = '0'
-	</select>
+        <select id="selectUserByUserName" parameterType="String" resultMap="SysUserResult">
+            <include refid="selectUserVo"/>
+                where u.user_name = #{userName} and u.del_flag = '0'
+        </select>
 	
-	<select id="selectUserById" parameterType="Long" resultMap="SysUserResult">
-		<include refid="selectUserVo"/>
-		where u.user_id = #{userId}
-	</select>
+        <select id="selectUserById" parameterType="Long" resultMap="SysUserResult">
+                <include refid="selectUserVo"/>
+                where u.user_id = #{userId}
+        </select>
 	
 	<select id="checkUserNameUnique" parameterType="String" resultMap="SysUserResult">
 		select user_id, user_name from sys_user where user_name = #{userName} and del_flag = '0' limit 1
@@ -213,11 +229,21 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
  		update sys_user set del_flag = '2' where user_id = #{userId}
  	</delete>
  	
- 	<delete id="deleteUserByIds" parameterType="Long">
- 		update sys_user set del_flag = '2' where user_id in
- 		<foreach collection="array" item="userId" open="(" separator="," close=")">
- 			#{userId}
-        </foreach> 
- 	</delete>
+        <delete id="deleteUserByIds" parameterType="Long">
+                update sys_user set del_flag = '2' where user_id in
+                <foreach collection="array" item="userId" open="(" separator="," close=")">
+                        #{userId}
+        </foreach>
+        </delete>
+
+        <select id="selectSimpleUserListByIds" resultType="SysUser">
+            select user_id, user_name, nick_name, status
+            from sys_user
+            where del_flag = '0'
+              and user_id in
+            <foreach collection="userIds" item="userId" open="(" separator="," close=")">
+                #{userId}
+            </foreach>
+        </select>
 	
 </mapper> 

--- a/ruoyi-ui/src/api/system/employee.js
+++ b/ruoyi-ui/src/api/system/employee.js
@@ -1,0 +1,102 @@
+import request from '@/utils/request'
+
+// 查询员工列表
+export function listEmployee(query) {
+  return request({
+    url: '/system/employee/list',
+    method: 'get',
+    params: query
+  })
+}
+
+// 查询员工详情
+export function getEmployee(employeeId) {
+  return request({
+    url: `/system/employee/${employeeId}`,
+    method: 'get'
+  })
+}
+
+// 新增员工
+export function addEmployee(data) {
+  return request({
+    url: '/system/employee',
+    method: 'post',
+    data
+  })
+}
+
+// 修改员工
+export function updateEmployee(data) {
+  return request({
+    url: '/system/employee',
+    method: 'put',
+    data
+  })
+}
+
+// 删除员工
+export function delEmployee(employeeId) {
+  return request({
+    url: `/system/employee/${employeeId}`,
+    method: 'delete'
+  })
+}
+
+// 员工状态修改
+export function changeEmployeeStatus(employeeId, status) {
+  const data = {
+    employeeId,
+    status
+  }
+  return request({
+    url: '/system/employee/changeStatus',
+    method: 'put',
+    data
+  })
+}
+
+// 导出员工
+export function exportEmployee(query) {
+  return request({
+    url: '/system/employee/export',
+    method: 'get',
+    params: query,
+    responseType: 'blob'
+  })
+}
+
+// 查询员工下拉选项（含可选绑定项）
+export function listEmployeeOptions(query) {
+  return request({
+    url: '/system/employee/options',
+    method: 'get',
+    params: query
+  })
+}
+
+// 查询可绑定账号列表
+export function listEmployeeBindCandidates(query) {
+  return request({
+    url: '/system/employee/bind/candidates',
+    method: 'get',
+    params: query
+  })
+}
+
+// 绑定账号
+export function bindEmployeeAccount(data) {
+  return request({
+    url: '/system/employee/bind',
+    method: 'post',
+    data
+  })
+}
+
+// 解绑账号
+export function unbindEmployeeAccount(employeeId) {
+  return request({
+    url: `/system/employee/${employeeId}/bind`,
+    method: 'delete'
+  })
+}

--- a/ruoyi-ui/src/views/system/employee/index.vue
+++ b/ruoyi-ui/src/views/system/employee/index.vue
@@ -1,0 +1,756 @@
+<template>
+  <div class="app-container employee-container">
+    <el-row :gutter="20">
+      <splitpanes :horizontal="$store.getters.device === 'mobile'" class="default-theme">
+        <pane size="16">
+          <el-col>
+            <div class="head-container">
+              <el-input
+                v-model="deptName"
+                placeholder="请输入部门名称"
+                clearable
+                size="small"
+                prefix-icon="el-icon-search"
+                style="margin-bottom: 20px"
+              />
+            </div>
+            <div class="head-container">
+              <el-tree
+                ref="tree"
+                :data="deptOptions"
+                :props="defaultProps"
+                :expand-on-click-node="false"
+                :filter-node-method="filterNode"
+                node-key="id"
+                default-expand-all
+                highlight-current
+                @node-click="handleNodeClick"
+              />
+            </div>
+          </el-col>
+        </pane>
+        <pane size="84">
+          <el-col>
+            <el-form
+              ref="queryForm"
+              :model="queryParams"
+              size="small"
+              :inline="true"
+              v-show="showSearch"
+              label-width="80px"
+            >
+              <el-form-item label="员工编号" prop="employeeCode">
+                <el-input
+                  v-model="queryParams.employeeCode"
+                  placeholder="请输入员工编号"
+                  clearable
+                  style="width: 240px"
+                  @keyup.enter.native="handleQuery"
+                />
+              </el-form-item>
+              <el-form-item label="员工姓名" prop="employeeName">
+                <el-input
+                  v-model="queryParams.employeeName"
+                  placeholder="请输入员工姓名"
+                  clearable
+                  style="width: 240px"
+                  @keyup.enter.native="handleQuery"
+                />
+              </el-form-item>
+              <el-form-item label="状态" prop="status">
+                <el-select v-model="queryParams.status" placeholder="员工状态" clearable style="width: 240px">
+                  <el-option
+                    v-for="dict in dict.type.sys_normal_disable"
+                    :key="dict.value"
+                    :label="dict.label"
+                    :value="dict.value"
+                  />
+                </el-select>
+              </el-form-item>
+              <el-form-item>
+                <el-button type="primary" icon="el-icon-search" size="mini" @click="handleQuery">搜索</el-button>
+                <el-button icon="el-icon-refresh" size="mini" @click="resetQuery">重置</el-button>
+              </el-form-item>
+            </el-form>
+
+            <el-row :gutter="10" class="mb8">
+              <el-col :span="1.5">
+                <el-button
+                  type="primary"
+                  plain
+                  icon="el-icon-plus"
+                  size="mini"
+                  @click="handleAdd"
+                  v-hasPermi="['system:employee:add']"
+                >新增</el-button>
+              </el-col>
+              <el-col :span="1.5">
+                <el-button
+                  type="success"
+                  plain
+                  icon="el-icon-edit"
+                  size="mini"
+                  :disabled="single"
+                  @click="handleUpdate"
+                  v-hasPermi="['system:employee:edit']"
+                >修改</el-button>
+              </el-col>
+              <el-col :span="1.5">
+                <el-button
+                  type="danger"
+                  plain
+                  icon="el-icon-delete"
+                  size="mini"
+                  :disabled="multiple"
+                  @click="handleDelete"
+                  v-hasPermi="['system:employee:remove']"
+                >删除</el-button>
+              </el-col>
+              <el-col :span="1.5">
+                <el-button
+                  type="warning"
+                  plain
+                  icon="el-icon-download"
+                  size="mini"
+                  @click="handleExport"
+                  v-hasPermi="['system:employee:export']"
+                >导出</el-button>
+              </el-col>
+              <right-toolbar :showSearch.sync="showSearch" @queryTable="getList" :columns="columns" />
+            </el-row>
+
+            <el-table v-loading="loading" :data="employeeList" @selection-change="handleSelectionChange">
+              <el-table-column type="selection" width="50" align="center" />
+              <el-table-column
+                v-if="columns.employeeCode.visible"
+                label="员工编号"
+                align="center"
+                key="employeeCode"
+                prop="employeeCode"
+                show-overflow-tooltip
+              />
+              <el-table-column
+                v-if="columns.employeeName.visible"
+                label="员工姓名"
+                align="center"
+                key="employeeName"
+                prop="employeeName"
+                show-overflow-tooltip
+              />
+              <el-table-column
+                v-if="columns.jobTitle.visible"
+                label="岗位"
+                align="center"
+                key="jobTitle"
+                prop="jobTitle"
+                show-overflow-tooltip
+              />
+              <el-table-column v-if="columns.deptNames.visible" label="所属部门" align="center" key="deptNames">
+                <template slot-scope="scope">
+                  <span>{{ formatDeptNames(scope.row.deptNames) }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column
+                v-if="columns.entryDate.visible"
+                label="入职日期"
+                align="center"
+                key="entryDate"
+                prop="entryDate"
+                width="120"
+              />
+              <el-table-column
+                v-if="columns.mobile.visible"
+                label="联系方式"
+                align="center"
+                key="mobile"
+                prop="mobile"
+                width="140"
+              />
+              <el-table-column v-if="columns.bindAccount.visible" label="绑定账号" align="center" key="bindAccount">
+                <template slot-scope="scope">
+                  <span v-if="scope.row.bindUser">
+                    {{ scope.row.bindUser.userName }}
+                    <span v-if="scope.row.bindUser.nickName" class="text-muted">（{{ scope.row.bindUser.nickName }}）</span>
+                  </span>
+                  <span v-else class="text-muted">未绑定</span>
+                </template>
+              </el-table-column>
+              <el-table-column v-if="columns.status.visible" label="状态" align="center" key="status">
+                <template slot-scope="scope">
+                  <el-switch
+                    v-model="scope.row.status"
+                    active-value="0"
+                    inactive-value="1"
+                    @change="handleStatusChange(scope.row)"
+                    v-hasPermi="['system:employee:edit']"
+                  />
+                </template>
+              </el-table-column>
+              <el-table-column label="操作" align="center" width="220" class-name="small-padding fixed-width">
+                <template slot-scope="scope">
+                  <el-button
+                    size="mini"
+                    type="text"
+                    icon="el-icon-view"
+                    @click="openDetail(scope.row)"
+                    v-hasPermi="['system:employee:query']"
+                  >详情</el-button>
+                  <el-button
+                    size="mini"
+                    type="text"
+                    icon="el-icon-edit"
+                    @click="handleUpdate(scope.row)"
+                    v-hasPermi="['system:employee:edit']"
+                  >修改</el-button>
+                  <el-button
+                    size="mini"
+                    type="text"
+                    icon="el-icon-delete"
+                    @click="handleDelete(scope.row)"
+                    v-hasPermi="['system:employee:remove']"
+                  >删除</el-button>
+                </template>
+              </el-table-column>
+            </el-table>
+
+            <pagination
+              v-show="total > 0"
+              :total="total"
+              :page.sync="queryParams.pageNum"
+              :limit.sync="queryParams.pageSize"
+              @pagination="getList"
+            />
+          </el-col>
+        </pane>
+      </splitpanes>
+    </el-row>
+
+    <el-dialog :title="title" :visible.sync="open" width="720px" append-to-body>
+      <el-form ref="form" :model="form" :rules="rules" label-width="90px">
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="员工编号" prop="employeeCode">
+              <el-input v-model="form.employeeCode" placeholder="请输入员工编号" maxlength="64" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="员工姓名" prop="employeeName">
+              <el-input v-model="form.employeeName" placeholder="请输入员工姓名" maxlength="50" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="岗位" prop="jobTitle">
+              <el-input v-model="form.jobTitle" placeholder="请输入岗位" maxlength="100" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="入职日期" prop="entryDate">
+              <el-date-picker
+                v-model="form.entryDate"
+                type="date"
+                value-format="yyyy-MM-dd"
+                placeholder="请选择入职日期"
+                style="width: 100%"
+              />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="联系方式" prop="mobile">
+              <el-input v-model="form.mobile" placeholder="请输入联系方式" maxlength="20" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="邮箱" prop="email">
+              <el-input v-model="form.email" placeholder="请输入邮箱" maxlength="100" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="状态" prop="status">
+              <el-radio-group v-model="form.status">
+                <el-radio v-for="dict in dict.type.sys_normal_disable" :key="dict.value" :label="dict.value">
+                  {{ dict.label }}
+                </el-radio>
+              </el-radio-group>
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="所属部门" prop="deptIds">
+              <treeselect
+                v-model="form.deptIds"
+                :options="enabledDeptOptions"
+                :show-count="true"
+                :multiple="true"
+                placeholder="请选择所属部门"
+              />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-row>
+          <el-col :span="24">
+            <el-form-item label="备注" prop="remark">
+              <el-input v-model="form.remark" type="textarea" placeholder="请输入内容" :rows="3" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+      </el-form>
+      <div slot="footer" class="dialog-footer">
+        <el-button type="primary" @click="submitForm">确 定</el-button>
+        <el-button @click="cancel">取 消</el-button>
+      </div>
+    </el-dialog>
+
+    <el-drawer
+      title="员工详情"
+      :visible.sync="detailVisible"
+      size="480px"
+      append-to-body
+      :destroy-on-close="true"
+    >
+      <div v-loading="detailLoading" class="employee-detail">
+        <el-descriptions v-if="detail" :column="1" border size="small">
+          <el-descriptions-item label="员工编号">{{ detail.employeeCode }}</el-descriptions-item>
+          <el-descriptions-item label="员工姓名">{{ detail.employeeName }}</el-descriptions-item>
+          <el-descriptions-item label="岗位">{{ detail.jobTitle || '-' }}</el-descriptions-item>
+          <el-descriptions-item label="入职日期">{{ detail.entryDate || '-' }}</el-descriptions-item>
+          <el-descriptions-item label="联系方式">{{ detail.mobile || '-' }}</el-descriptions-item>
+          <el-descriptions-item label="邮箱">{{ detail.email || '-' }}</el-descriptions-item>
+          <el-descriptions-item label="所属部门">
+            {{ formatDeptNames(detail.deptNames) || '-' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="状态">
+            <dict-tag :options="dict.type.sys_normal_disable" :value="detail.status" />
+          </el-descriptions-item>
+          <el-descriptions-item label="账号绑定">
+            <template v-if="detail.bindUser">
+              <div class="bind-user">
+                <span>{{ detail.bindUser.userName }}</span>
+                <span v-if="detail.bindUser.nickName" class="text-muted">（{{ detail.bindUser.nickName }}）</span>
+                <el-button
+                  v-hasPermi="['system:employee:bind']"
+                  type="text"
+                  size="mini"
+                  class="ml10"
+                  @click="handleUnbind(detail)"
+                >解绑</el-button>
+              </div>
+            </template>
+            <template v-else>
+              <span class="text-muted">未绑定</span>
+              <el-button
+                v-hasPermi="['system:employee:bind']"
+                type="text"
+                size="mini"
+                class="ml10"
+                @click="openBindDialog(detail)"
+              >绑定账号</el-button>
+            </template>
+          </el-descriptions-item>
+          <el-descriptions-item label="备注">{{ detail.remark || '-' }}</el-descriptions-item>
+        </el-descriptions>
+      </div>
+    </el-drawer>
+
+    <el-dialog
+      title="绑定账号"
+      :visible.sync="bindDialogVisible"
+      width="420px"
+      append-to-body
+      :close-on-click-modal="false"
+    >
+      <el-form :model="bindForm" label-width="90px">
+        <el-form-item label="选择账号" prop="userId">
+          <el-select
+            v-model="bindForm.userId"
+            filterable
+            clearable
+            remote
+            reserve-keyword
+            placeholder="请输入账号名称搜索"
+            :remote-method="searchBindCandidates"
+            :loading="bindCandidatesLoading"
+          >
+            <el-option
+              v-for="user in bindCandidates"
+              :key="user.userId"
+              :label="formatUserOption(user)"
+              :value="user.userId"
+            />
+          </el-select>
+        </el-form-item>
+      </el-form>
+      <div slot="footer" class="dialog-footer">
+        <el-button type="primary" :loading="bindLoading" @click="confirmBind">绑 定</el-button>
+        <el-button @click="bindDialogVisible = false">取 消</el-button>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import {
+  listEmployee,
+  getEmployee,
+  addEmployee,
+  updateEmployee,
+  delEmployee,
+  changeEmployeeStatus,
+  exportEmployee,
+  listEmployeeBindCandidates,
+  bindEmployeeAccount,
+  unbindEmployeeAccount
+} from '@/api/system/employee'
+import { deptTreeSelect } from '@/api/system/user'
+import Treeselect from '@riophae/vue-treeselect'
+import '@riophae/vue-treeselect/dist/vue-treeselect.css'
+import { Splitpanes, Pane } from 'splitpanes'
+import 'splitpanes/dist/splitpanes.css'
+
+export default {
+  name: 'Employee',
+  components: { Treeselect, Splitpanes, Pane },
+  dicts: ['sys_normal_disable'],
+  data() {
+    return {
+      loading: false,
+      ids: [],
+      single: true,
+      multiple: true,
+      showSearch: true,
+      total: 0,
+      employeeList: [],
+      title: '',
+      open: false,
+      deptOptions: [],
+      enabledDeptOptions: [],
+      deptName: undefined,
+      defaultProps: {
+        children: 'children',
+        label: 'label'
+      },
+      queryParams: {
+        pageNum: 1,
+        pageSize: 10,
+        employeeCode: undefined,
+        employeeName: undefined,
+        status: undefined,
+        deptId: undefined
+      },
+      columns: {
+        employeeCode: { label: '员工编号', visible: true },
+        employeeName: { label: '员工姓名', visible: true },
+        jobTitle: { label: '岗位', visible: true },
+        deptNames: { label: '所属部门', visible: true },
+        entryDate: { label: '入职日期', visible: true },
+        mobile: { label: '联系方式', visible: true },
+        bindAccount: { label: '绑定账号', visible: true },
+        status: { label: '状态', visible: true }
+      },
+      form: {
+        employeeId: undefined,
+        employeeCode: undefined,
+        employeeName: undefined,
+        jobTitle: undefined,
+        entryDate: undefined,
+        mobile: undefined,
+        email: undefined,
+        status: '0',
+        remark: undefined,
+        deptIds: []
+      },
+      rules: {
+        employeeCode: [
+          { required: true, message: '员工编号不能为空', trigger: 'blur' },
+          { min: 1, max: 64, message: '员工编号长度必须介于 1 和 64 之间', trigger: 'blur' }
+        ],
+        employeeName: [
+          { required: true, message: '员工姓名不能为空', trigger: 'blur' }
+        ],
+        email: [
+          { type: 'email', message: '请输入正确的邮箱地址', trigger: ['blur', 'change'] }
+        ],
+        mobile: [
+          {
+            pattern: /^1[3-9]\d{9}$/,
+            message: '请输入正确的手机号码',
+            trigger: 'blur',
+            transform(value) {
+              return value || ''
+            }
+          }
+        ],
+        deptIds: [
+          { type: 'array', required: true, message: '请选择所属部门', trigger: 'change' }
+        ]
+      },
+      detailVisible: false,
+      detailLoading: false,
+      detail: null,
+      bindDialogVisible: false,
+      bindForm: {
+        employeeId: undefined,
+        userId: undefined
+      },
+      bindCandidates: [],
+      bindCandidatesLoading: false,
+      bindLoading: false
+    }
+  },
+  watch: {
+    deptName(val) {
+      if (this.$refs.tree) {
+        this.$refs.tree.filter(val)
+      }
+    }
+  },
+  created() {
+    this.getList()
+    this.getDeptTree()
+  },
+  methods: {
+    getList() {
+      this.loading = true
+      listEmployee(this.queryParams).then(response => {
+        this.employeeList = response.rows || []
+        this.total = response.total || 0
+        this.loading = false
+      }).catch(() => {
+        this.loading = false
+      })
+    },
+    getDeptTree() {
+      deptTreeSelect().then(response => {
+        this.deptOptions = response.data || []
+        this.enabledDeptOptions = this.filterDisabledDept(JSON.parse(JSON.stringify(this.deptOptions || [])))
+      })
+    },
+    filterDisabledDept(deptList) {
+      return deptList.filter(dept => {
+        if (dept.disabled) {
+          return false
+        }
+        if (dept.children && dept.children.length) {
+          dept.children = this.filterDisabledDept(dept.children)
+        }
+        return true
+      })
+    },
+    filterNode(value, data) {
+      if (!value) return true
+      return data.label.indexOf(value) !== -1
+    },
+    handleNodeClick(data) {
+      this.queryParams.deptId = data.id
+      this.handleQuery()
+    },
+    handleStatusChange(row) {
+      const text = row.status === '0' ? '启用' : '停用'
+      this.$modal.confirm('确认要"' + text + '""' + row.employeeName + '"员工吗？').then(() => {
+        return changeEmployeeStatus(row.employeeId, row.status)
+      }).then(() => {
+        this.$modal.msgSuccess(text + '成功')
+      }).catch(() => {
+        row.status = row.status === '0' ? '1' : '0'
+      })
+    },
+    cancel() {
+      this.open = false
+      this.reset()
+    },
+    reset() {
+      this.form = {
+        employeeId: undefined,
+        employeeCode: undefined,
+        employeeName: undefined,
+        jobTitle: undefined,
+        entryDate: undefined,
+        mobile: undefined,
+        email: undefined,
+        status: '0',
+        remark: undefined,
+        deptIds: []
+      }
+      this.resetForm('form')
+    },
+    handleQuery() {
+      this.queryParams.pageNum = 1
+      this.getList()
+    },
+    resetQuery() {
+      this.resetForm('queryForm')
+      this.queryParams.deptId = undefined
+      this.deptName = undefined
+      if (this.$refs.tree) {
+        this.$refs.tree.setCurrentKey(null)
+      }
+      this.handleQuery()
+    },
+    handleSelectionChange(selection) {
+      this.ids = selection.map(item => item.employeeId)
+      this.single = selection.length !== 1
+      this.multiple = !selection.length
+    },
+    handleAdd() {
+      this.reset()
+      this.open = true
+      this.title = '新增员工'
+    },
+    handleUpdate(row) {
+      const employeeId = row.employeeId || this.ids[0]
+      if (!employeeId) {
+        return
+      }
+      this.reset()
+      getEmployee(employeeId).then(response => {
+        const data = response.data || {}
+        this.form = {
+          employeeId: data.employeeId,
+          employeeCode: data.employeeCode,
+          employeeName: data.employeeName,
+          jobTitle: data.jobTitle,
+          entryDate: data.entryDate,
+          mobile: data.mobile,
+          email: data.email,
+          status: data.status || '0',
+          remark: data.remark,
+          deptIds: data.deptIds || []
+        }
+        this.open = true
+        this.title = '修改员工'
+      })
+    },
+    submitForm() {
+      this.$refs['form'].validate(valid => {
+        if (!valid) {
+          return
+        }
+        const submit = this.form.employeeId ? updateEmployee : addEmployee
+        submit(this.form).then(() => {
+          this.$modal.msgSuccess(this.form.employeeId ? '修改成功' : '新增成功')
+          this.open = false
+          this.getList()
+        })
+      })
+    },
+    handleDelete(row) {
+      const employeeIds = row.employeeId || this.ids
+      if (!employeeIds || (Array.isArray(employeeIds) && !employeeIds.length)) {
+        return
+      }
+      this.$modal.confirm('是否确认删除员工编号为"' + employeeIds + '"的数据项？').then(() => {
+        return delEmployee(employeeIds)
+      }).then(() => {
+        this.getList()
+        this.$modal.msgSuccess('删除成功')
+      }).catch(() => {})
+    },
+    handleExport() {
+      this.download('system/employee/export', { ...this.queryParams }, `employee_${new Date().getTime()}.xlsx`)
+    },
+    formatDeptNames(deptNames) {
+      if (!deptNames) {
+        return ''
+      }
+      if (Array.isArray(deptNames)) {
+        return deptNames.join('、')
+      }
+      return deptNames
+    },
+    openDetail(row) {
+      this.detailVisible = true
+      this.detailLoading = true
+      getEmployee(row.employeeId).then(response => {
+        this.detail = response.data || null
+        this.detailLoading = false
+      }).catch(() => {
+        this.detailLoading = false
+      })
+    },
+    openBindDialog(detail) {
+      this.bindForm = {
+        employeeId: detail.employeeId,
+        userId: undefined
+      }
+      this.bindCandidates = []
+      this.bindDialogVisible = true
+    },
+    searchBindCandidates(keyword) {
+      this.bindCandidatesLoading = true
+      listEmployeeBindCandidates({ keyword, employeeId: this.bindForm.employeeId }).then(response => {
+        this.bindCandidates = response.data || response.rows || []
+        this.bindCandidatesLoading = false
+      }).catch(() => {
+        this.bindCandidatesLoading = false
+      })
+    },
+    confirmBind() {
+      if (!this.bindForm.userId) {
+        this.$modal.msgWarning('请选择需要绑定的账号')
+        return
+      }
+      this.bindLoading = true
+      bindEmployeeAccount(this.bindForm).then(() => {
+        this.$modal.msgSuccess('绑定成功')
+        this.bindLoading = false
+        this.bindDialogVisible = false
+        if (this.detailVisible) {
+          this.refreshDetail()
+        }
+        this.getList()
+      }).catch(() => {
+        this.bindLoading = false
+      })
+    },
+    handleUnbind(detail) {
+      this.$modal.confirm('确认要解绑当前账号吗？').then(() => {
+        return unbindEmployeeAccount(detail.employeeId)
+      }).then(() => {
+        this.$modal.msgSuccess('解绑成功')
+        if (this.detailVisible) {
+          this.refreshDetail()
+        }
+        this.getList()
+      }).catch(() => {})
+    },
+    refreshDetail() {
+      if (!this.detail) {
+        return
+      }
+      this.detailLoading = true
+      getEmployee(this.detail.employeeId).then(response => {
+        this.detail = response.data || null
+        this.detailLoading = false
+      }).catch(() => {
+        this.detailLoading = false
+      })
+    },
+    formatUserOption(user) {
+      if (!user) {
+        return ''
+      }
+      const base = user.userName || ''
+      if (user.nickName) {
+        return `${base}（${user.nickName}）`
+      }
+      return base
+    }
+  }
+}
+</script>
+
+<style scoped>
+.employee-container .text-muted {
+  color: #909399;
+}
+.employee-detail {
+  padding-right: 8px;
+}
+.ml10 {
+  margin-left: 10px;
+}
+</style>

--- a/sql/ry_20250522_employee_module.sql
+++ b/sql/ry_20250522_employee_module.sql
@@ -1,0 +1,102 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ----------------------------
+-- 1、员工信息表
+-- ----------------------------
+DROP TABLE IF EXISTS `sys_employee`;
+CREATE TABLE `sys_employee` (
+  `employee_id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '员工ID',
+  `employee_code` varchar(64) NOT NULL DEFAULT '' COMMENT '员工编号',
+  `employee_name` varchar(50) NOT NULL COMMENT '员工姓名',
+  `job_title` varchar(100) DEFAULT NULL COMMENT '岗位',
+  `entry_date` date DEFAULT NULL COMMENT '入职日期',
+  `mobile` varchar(20) DEFAULT NULL COMMENT '联系方式',
+  `email` varchar(100) DEFAULT NULL COMMENT '邮箱',
+  `status` char(1) NOT NULL DEFAULT '0' COMMENT '员工状态（0在职 1离职）',
+  `del_flag` char(1) NOT NULL DEFAULT '0' COMMENT '删除标志（0代表存在 2代表删除）',
+  `create_by` varchar(64) DEFAULT '' COMMENT '创建者',
+  `create_time` datetime DEFAULT NULL COMMENT '创建时间',
+  `update_by` varchar(64) DEFAULT '' COMMENT '更新者',
+  `update_time` datetime DEFAULT NULL COMMENT '更新时间',
+  `remark` varchar(500) DEFAULT NULL COMMENT '备注',
+  PRIMARY KEY (`employee_id`),
+  UNIQUE KEY `uk_employee_code` (`employee_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='员工信息表';
+
+-- ----------------------------
+-- 初始化-员工信息表数据
+-- ----------------------------
+INSERT INTO `sys_employee` (`employee_id`, `employee_code`, `employee_name`, `job_title`, `entry_date`, `mobile`, `email`, `status`, `del_flag`, `create_by`, `create_time`, `remark`)
+VALUES
+  (2001, 'E2024001', '张三', '高级工程师', '2023-03-18', '13800000001', 'zhangsan@example.com', '0', '0', 'admin', sysdate(), '资深后端工程师'),
+  (2002, 'E2024002', '李四', '测试经理', '2022-11-02', '13800000002', 'lisi@example.com', '0', '0', 'admin', sysdate(), '长沙分公司测试负责人');
+
+-- ----------------------------
+-- 2、员工与部门关联表
+-- ----------------------------
+DROP TABLE IF EXISTS `sys_employee_dept`;
+CREATE TABLE `sys_employee_dept` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `employee_id` bigint(20) NOT NULL COMMENT '员工ID',
+  `dept_id` bigint(20) NOT NULL COMMENT '部门ID',
+  `create_time` datetime DEFAULT NULL COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_employee_dept` (`employee_id`,`dept_id`),
+  KEY `idx_employee_dept_dept` (`dept_id`),
+  CONSTRAINT `fk_employee_dept_employee` FOREIGN KEY (`employee_id`) REFERENCES `sys_employee` (`employee_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_employee_dept_dept` FOREIGN KEY (`dept_id`) REFERENCES `sys_dept` (`dept_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='员工与部门关联表';
+
+-- ----------------------------
+-- 初始化-员工与部门关联表数据
+-- ----------------------------
+INSERT INTO `sys_employee_dept` (`id`, `employee_id`, `dept_id`, `create_time`)
+VALUES
+  (3001, 2001, 103, sysdate()),
+  (3002, 2001, 107, sysdate()),
+  (3003, 2002, 105, sysdate());
+
+-- ----------------------------
+-- 3、账号与员工绑定表
+-- ----------------------------
+DROP TABLE IF EXISTS `sys_user_employee`;
+CREATE TABLE `sys_user_employee` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `user_id` bigint(20) NOT NULL COMMENT '账号ID',
+  `employee_id` bigint(20) NOT NULL COMMENT '员工ID',
+  `create_time` datetime DEFAULT NULL COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_employee_user` (`user_id`),
+  UNIQUE KEY `uk_user_employee_employee` (`employee_id`),
+  CONSTRAINT `fk_user_employee_user` FOREIGN KEY (`user_id`) REFERENCES `sys_user` (`user_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_user_employee_employee` FOREIGN KEY (`employee_id`) REFERENCES `sys_employee` (`employee_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='账号与员工绑定表';
+
+-- ----------------------------
+-- 初始化-账号与员工绑定数据
+-- ----------------------------
+INSERT INTO `sys_user_employee` (`id`, `user_id`, `employee_id`, `create_time`)
+VALUES
+  (4001, 1, 2001, sysdate());
+
+-- ----------------------------
+-- 4、员工管理菜单
+-- ----------------------------
+INSERT INTO `sys_menu` VALUES ('118', '员工管理', '1', '10', 'employee', 'system/employee/index', '', '', 1, 0, 'C', '0', '0', 'system:employee:list', 'user', 'admin', sysdate(), '', NULL, '员工管理菜单');
+INSERT INTO `sys_menu` VALUES ('1200', '员工查询', '118', '1', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:query', '#', 'admin', sysdate(), '', NULL, '');
+INSERT INTO `sys_menu` VALUES ('1201', '员工新增', '118', '2', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:add', '#', 'admin', sysdate(), '', NULL, '');
+INSERT INTO `sys_menu` VALUES ('1202', '员工修改', '118', '3', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:edit', '#', 'admin', sysdate(), '', NULL, '');
+INSERT INTO `sys_menu` VALUES ('1203', '员工删除', '118', '4', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:remove', '#', 'admin', sysdate(), '', NULL, '');
+INSERT INTO `sys_menu` VALUES ('1204', '员工导出', '118', '5', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:export', '#', 'admin', sysdate(), '', NULL, '');
+INSERT INTO `sys_menu` VALUES ('1205', '账号绑定', '118', '6', '', '', '', '', 1, 0, 'F', '0', '0', 'system:employee:bind', '#', 'admin', sysdate(), '', NULL, '');
+
+INSERT INTO `sys_role_menu` VALUES ('2', '118');
+INSERT INTO `sys_role_menu` VALUES ('2', '1200');
+INSERT INTO `sys_role_menu` VALUES ('2', '1201');
+INSERT INTO `sys_role_menu` VALUES ('2', '1202');
+INSERT INTO `sys_role_menu` VALUES ('2', '1203');
+INSERT INTO `sys_role_menu` VALUES ('2', '1204');
+INSERT INTO `sys_role_menu` VALUES ('2', '1205');
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## Summary
- add the employee controller and MyBatis Plus service layer to expose list/detail CRUD, status, option, and bind endpoints required by the new UI
- integrate employee bindings with user and department operations and seed the employee menu/buttons in the SQL script for immediate navigation

## Testing
- mvn -pl ruoyi-system -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68db7b89eb3c8320bd1385b05e25f465