### PR TITLE
fix: ensure department deletion flag loads for employees

### DIFF
--- a/ruoyi-system/pom.xml
+++ b/ruoyi-system/pom.xml
@@ -29,6 +29,25 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- 测试依赖 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+            <version>4.11.0</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/ruoyi-system/src/main/resources/mapper/system/SysDeptMapper.xml
+++ b/ruoyi-system/src/main/resources/mapper/system/SysDeptMapper.xml
@@ -59,11 +59,12 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	</select>
     
     <select id="selectDeptById" parameterType="Long" resultMap="SysDeptResult">
-		select d.dept_id, d.parent_id, d.ancestors, d.dept_name, d.order_num, d.leader, d.phone, d.email, d.status,
-			(select dept_name from sys_dept where dept_id = d.parent_id) parent_name
-		from sys_dept d
-		where d.dept_id = #{deptId}
-	</select>
+                select d.dept_id, d.parent_id, d.ancestors, d.dept_name, d.order_num, d.leader, d.phone, d.email, d.status,
+                       d.del_flag, d.create_by, d.create_time, d.update_by, d.update_time,
+                        (select dept_name from sys_dept where dept_id = d.parent_id) parent_name
+                from sys_dept d
+                where d.dept_id = #{deptId}
+        </select>
     
         <select id="checkDeptExistUser" parameterType="Long" resultType="int">
                 select count(1) from sys_user where dept_id = #{deptId} and del_flag = '0'

--- a/ruoyi-system/src/test/java/com/ruoyi/system/service/impl/SysEmployeeServiceImplTest.java
+++ b/ruoyi-system/src/test/java/com/ruoyi/system/service/impl/SysEmployeeServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.ruoyi.system.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ruoyi.common.constant.UserConstants;
+import com.ruoyi.common.core.domain.entity.SysDept;
+import com.ruoyi.system.domain.employee.SysEmployee;
+import com.ruoyi.system.mapper.SysDeptMapper;
+import com.ruoyi.system.mapper.SysEmployeeMapper;
+import com.ruoyi.system.service.ISysDeptService;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SysEmployeeServiceImplTest
+{
+    @InjectMocks
+    private SysEmployeeServiceImpl employeeService;
+
+    @Mock
+    private SysEmployeeMapper employeeMapper;
+
+    @Mock
+    private ISysDeptService deptService;
+
+    @Mock
+    private SysDeptMapper deptMapper;
+
+    @BeforeEach
+    void setUp()
+    {
+        ReflectionTestUtils.setField(employeeService, "baseMapper", employeeMapper);
+    }
+
+    @Test
+    @DisplayName("校验通过时不会抛出部门不存在异常")
+    void validateEmployeeShouldPassWhenDeptNormal()
+    {
+        SysEmployee employee = new SysEmployee();
+        employee.setEmployeeCode("E001");
+        employee.setEmployeeName("张三");
+        employee.setDeptIds(Collections.singletonList(1L));
+
+        when(employeeMapper.selectCount(any())).thenReturn(0L);
+
+        SysDept dept = new SysDept();
+        dept.setDeptId(1L);
+        dept.setDeptName("测试部门");
+        dept.setDelFlag(UserConstants.NORMAL);
+        dept.setStatus(UserConstants.DEPT_NORMAL);
+        when(deptMapper.selectDeptById(1L)).thenReturn(dept);
+
+        assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(employeeService, "validateEmployee", employee, true));
+
+        verify(deptService).checkDeptDataScope(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- 在 SysDeptMapper 的 selectDeptById 查询中补齐 del_flag 及审计字段，保证部门逻辑删除状态可用
- 为 ruoyi-system 模块补充测试依赖并新增 SysEmployeeServiceImpl 的校验单元测试，验证部门校验通过时不会抛错

## Testing
- mvn -pl ruoyi-system test *(因外部仓库 403 Forbidden 无法解析 com.ruoyi:ruoyi-common 依赖)*

------
https://chatgpt.com/codex/tasks/task_e_68de89a3aff08320bd1f0c6fd8d90054