### PR TITLE
feat: 为员工模块提供部门树接口

### DIFF
--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysDeptController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/SysDeptController.java
@@ -35,6 +35,16 @@ public class SysDeptController extends BaseController
     private ISysDeptService deptService;
 
     /**
+     * 获取员工模块使用的部门树
+     */
+    @PreAuthorize("@ss.hasPermi('system:employee:list')")
+    @GetMapping("/employee/tree")
+    public AjaxResult employeeDeptTree(SysDept dept)
+    {
+        return success(deptService.selectDeptTreeList(dept));
+    }
+
+    /**
      * 获取部门列表
      */
     @PreAuthorize("@ss.hasPermi('system:dept:list')")

--- a/ruoyi-ui/src/api/system/employee.js
+++ b/ruoyi-ui/src/api/system/employee.js
@@ -100,3 +100,11 @@ export function unbindEmployeeAccount(employeeId) {
     method: 'delete'
   })
 }
+
+// 查询员工模块可用的部门下拉树结构
+export function deptTreeSelect() {
+  return request({
+    url: '/system/dept/employee/tree',
+    method: 'get'
+  })
+}

--- a/ruoyi-ui/src/views/system/employee/index.vue
+++ b/ruoyi-ui/src/views/system/employee/index.vue
@@ -403,9 +403,9 @@ import {
   exportEmployee,
   listEmployeeBindCandidates,
   bindEmployeeAccount,
-  unbindEmployeeAccount
+  unbindEmployeeAccount,
+  deptTreeSelect
 } from '@/api/system/employee'
-import { deptTreeSelect } from '@/api/system/user'
 import Treeselect from '@riophae/vue-treeselect'
 import '@riophae/vue-treeselect/dist/vue-treeselect.css'
 import { Splitpanes, Pane } from 'splitpanes'


### PR DESCRIPTION
## Summary
- 新增 /system/dept/employee/tree 接口并限定 system:employee:list 权限可访问
- 员工管理页面改用新的部门树 API，保持返回数据结构不变

## Testing
- 未执行自动化测试（前端改动需手动验证）

------
https://chatgpt.com/codex/tasks/task_e_68de89a3f234832088a7534d71c4bb83